### PR TITLE
set xenon lights for headlightColor usage if not setted before, ignor…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -296,3 +296,4 @@ __pycache__/
 [Bb]uild-linux/
 
 .vscode
+/dist

--- a/src/bindings/vehicle/GameState.h
+++ b/src/bindings/vehicle/GameState.h
@@ -73,7 +73,12 @@ namespace V8::Vehicle
 		V8_CHECK(_this, "entity is invalid");
 
 		Ref<IVehicle> vehicle = _this->GetHandle().As<IVehicle>();
-
+		if (vehicle->GetModKit() == 0) {
+			vehicle->SetModKit(1);
+		}
+		if (vehicle->GetMod(22) == 0) {
+			vehicle->SetMod(22, 1);
+		}
 		vehicle->SetHeadlightColor(value->ToInteger(info.GetIsolate())->Value());
 	}
 


### PR DESCRIPTION
…e dist dir in gitignore

devs will not need to set modkit and xenon mod before setting headlightColor anymore