### PR TITLE
Add colshape isPointIn

### DIFF
--- a/src/bindings/ColShape.cpp
+++ b/src/bindings/ColShape.cpp
@@ -32,10 +32,12 @@ static void IsEntityIn(const v8::FunctionCallbackInfo<v8::Value>& info)
 static void IsPointIn(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
 	v8::Isolate* isolate = info.GetIsolate();
+	v8::Local<v8::Context> ctx = isolate->GetEnteredContext();
 
-	V8_CHECK(info.Length() == 3, "3 args expected");
+	V8_CHECK(info.Length() == 1, "1 arg expected");
+	V8_CHECK(info[0]->IsObject(), "object expected");
 
-	V8ResourceImpl* resource = V8ResourceImpl::Get(isolate->GetEnteredContext());
+	V8ResourceImpl* resource = V8ResourceImpl::Get(ctx);
 	V8_CHECK(resource, "invalid resource");
 
 	V8Entity* _this = V8Entity::Get(info.This());
@@ -43,12 +45,13 @@ static void IsPointIn(const v8::FunctionCallbackInfo<v8::Value>& info)
 
 	Ref<IColShape> cs = _this->GetHandle().As<IColShape>();
 
-	v8::Local<v8::Number> x = info[0]->ToNumber(isolate);
-	v8::Local<v8::Number> y = info[1]->ToNumber(isolate);
-	v8::Local<v8::Number> z = info[2]->ToNumber(isolate);
+	v8::Local<v8::Object> pos = info[0].As<v8::Object>();
 
-	alt::Position pos(x->Value(), y->Value(), z->Value());
-	bool pointIn = cs->IsPointIn(pos);
+	v8::Local<v8::Number> x = V8::Get(ctx, pos, "x")->ToNumber(ctx).ToLocalChecked();
+	v8::Local<v8::Number> y = V8::Get(ctx, pos, "y")->ToNumber(ctx).ToLocalChecked();
+	v8::Local<v8::Number> z = V8::Get(ctx, pos, "z")->ToNumber(ctx).ToLocalChecked();
+
+	bool pointIn = cs->IsPointIn({ x->Value(), y->Value(), z->Value() });
 
 	info.GetReturnValue().Set(v8::Boolean::New(isolate, pointIn));
 }

--- a/src/bindings/ColShape.cpp
+++ b/src/bindings/ColShape.cpp
@@ -84,7 +84,7 @@ static V8Class v8Colshape("Colshape", "WorldObject", nullptr, [](v8::Local<v8::F
 	V8::SetAccessor(isolate, tpl, "colshapeType", ColshapeTypeGetter);
 	V8::SetAccessor(isolate, tpl, "playersOnly", PlayersOnlyGetter, PlayersOnlySetter);
 	V8::SetMethod(isolate, tpl, "isEntityIn", IsEntityIn);
-    V8::SetMethod(isolate, tpl, "isPointIn", IsPointIn);
+	V8::SetMethod(isolate, tpl, "isPointIn", IsPointIn);
 });
 
 static V8Class v8ColshapeCylinder("ColshapeCylinder", "Colshape", [](const v8::FunctionCallbackInfo<v8::Value>& info)

--- a/src/bindings/ColShape.cpp
+++ b/src/bindings/ColShape.cpp
@@ -31,19 +31,11 @@ static void IsEntityIn(const v8::FunctionCallbackInfo<v8::Value>& info)
 
 static void IsPointIn(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
-	v8::Isolate* isolate = info.GetIsolate();
-	v8::Local<v8::Context> ctx = isolate->GetEnteredContext();
+	V8_GET_ISOLATE_CONTEXT_RESOURCE();
+	V8_GET_THIS_BASE_OBJECT(_this, IColShape);
 
-	V8_CHECK(info.Length() == 1, "1 arg expected");
+	V8_CHECK_ARGS_LEN(1);
 	V8_CHECK(info[0]->IsObject(), "object expected");
-
-	V8ResourceImpl* resource = V8ResourceImpl::Get(ctx);
-	V8_CHECK(resource, "invalid resource");
-
-	V8Entity* _this = V8Entity::Get(info.This());
-	V8_CHECK(_this, "entity is invalid");
-
-	Ref<IColShape> cs = _this->GetHandle().As<IColShape>();
 
 	v8::Local<v8::Object> pos = info[0].As<v8::Object>();
 
@@ -51,9 +43,7 @@ static void IsPointIn(const v8::FunctionCallbackInfo<v8::Value>& info)
 	v8::Local<v8::Number> y = V8::Get(ctx, pos, "y")->ToNumber(ctx).ToLocalChecked();
 	v8::Local<v8::Number> z = V8::Get(ctx, pos, "z")->ToNumber(ctx).ToLocalChecked();
 
-	bool pointIn = cs->IsPointIn({ x->Value(), y->Value(), z->Value() });
-
-	info.GetReturnValue().Set(v8::Boolean::New(isolate, pointIn));
+	V8_RETURN_BOOLEAN(_this->IsPointIn({ x->Value(), y->Value(), z->Value() }));
 }
 
 static void ColshapeTypeGetter(v8::Local<v8::String> name, const v8::PropertyCallbackInfo<v8::Value>& info)

--- a/src/bindings/ColShape.cpp
+++ b/src/bindings/ColShape.cpp
@@ -29,6 +29,30 @@ static void IsEntityIn(const v8::FunctionCallbackInfo<v8::Value>& info)
 	info.GetReturnValue().Set(v8::Boolean::New(isolate, entityIn));
 }
 
+static void IsPointIn(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+	v8::Isolate* isolate = info.GetIsolate();
+
+	V8_CHECK(info.Length() == 3, "3 args expected");
+
+	V8ResourceImpl* resource = V8ResourceImpl::Get(isolate->GetEnteredContext());
+	V8_CHECK(resource, "invalid resource");
+
+	V8Entity* _this = V8Entity::Get(info.This());
+	V8_CHECK(_this, "entity is invalid");
+
+	Ref<IColShape> cs = _this->GetHandle().As<IColShape>();
+
+	v8::Local<v8::Number> x = info[0]->ToNumber(isolate);
+	v8::Local<v8::Number> y = info[1]->ToNumber(isolate);
+	v8::Local<v8::Number> z = info[2]->ToNumber(isolate);
+
+	alt::Position pos(x->Value(), y->Value(), z->Value());
+	bool pointIn = cs->IsPointIn(pos);
+
+	info.GetReturnValue().Set(v8::Boolean::New(isolate, pointIn));
+}
+
 static void ColshapeTypeGetter(v8::Local<v8::String> name, const v8::PropertyCallbackInfo<v8::Value>& info)
 {
 	v8::Isolate* isolate = info.GetIsolate();
@@ -52,6 +76,7 @@ static V8Class v8Colshape("Colshape", "WorldObject", nullptr, [](v8::Local<v8::F
 	//Common getter/setters
 	proto->SetAccessor(v8::String::NewFromUtf8(isolate, "colshapeType"), &ColshapeTypeGetter);
 	proto->Set(v8::String::NewFromUtf8(isolate, "isEntityIn"), v8::FunctionTemplate::New(isolate, &IsEntityIn));
+	proto->Set(v8::String::NewFromUtf8(isolate, "isPointIn"), v8::FunctionTemplate::New(isolate, &IsPointIn));
 });
 
 static V8Class v8ColshapeCylinder("ColshapeCylinder", "Colshape", [](const v8::FunctionCallbackInfo<v8::Value>& info)


### PR DESCRIPTION
Adds `isPointIn(position: alt.Vector3)` to colshapes.

Related type def PR: https://github.com/altmp/altv-types/pull/1

Test JS:
```js
import alt from 'alt-server';

const cs = new alt.ColshapeSphere(100, 100, 100, 5);

console.log(typeof cs.isPointIn);

[
	new alt.Vector3(100, 100, 100),
	new alt.Vector3(100, 106, 100),
	new alt.Vector3(97, 102, 98)
].forEach(point => {
	console.log(`isPointIn: ${point}? ${cs.isPointIn(point)}`);
});
```

Test Result:
```
function
isPointIn: Vector3{ x: 100, y: 100, z: 100 }? true
isPointIn: Vector3{ x: 100, y: 106, z: 100 }? false
isPointIn: Vector3{ x: 97, y: 102, z: 98 }? true
```

```