### PR TITLE
Add troubleshooting guide for native Node.js modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # altv-js-module
 JS module for alt:V Multiplayer. Powered by NodeJS &amp; v8
+
+## Troubleshooting
+**Problem**: I want to build a native Node.js addon with
+[node-gyp](https://github.com/nodejs/node-gyp) but the alt:V server can not load
+it and responds with following error:
+```
+./altv-server: symbol lookup error: /usr/share/addon/binding.node: undefined symbol: node_module_register
+```
+**Solution**: Add a C++ file to your project with following content and include
+it the  ```sources``` in your ```binding.gyp``` file.
+```cpp
+#include <node.h>
+#include <dlfcn.h>
+
+extern "C" NODE_EXTERN void node_module_register(void* mod) {
+  auto base_ptr = dlopen("libnode.so.72", RTLD_NOW | RTLD_GLOBAL);
+  if (base_ptr == nullptr) {
+    return;
+  }
+  auto register_func = reinterpret_cast<decltype(&node_module_register)>(dlsym(base_ptr, "node_module_register"));
+  if (register_func == nullptr) {
+    return;
+  }
+  register_func(mod);
+}


### PR DESCRIPTION
Hello,

I have experienced some issues with developing a native Node.js addons in C++ with node-gyp. The problem is that the altv-server executable has no visible exported ```node_module_register```function where the addon can register itself. This function is part of the libnode.so file. However, this "workaround" reimplements this function and forwards this call to the libnode.so module and this helps the module to register the addon in the V8 engine. I am not sure if this is the right place to document this but feel free to reject the PR or document it somewhere else 👍 

PS: This fix only works on Linux - I could not find any solution for Windows unfortunately.