### PR TITLE
feat: support generic event handler

### DIFF
--- a/src/bindings/Main.cpp
+++ b/src/bindings/Main.cpp
@@ -9,30 +9,54 @@ static void OnClient(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
 	v8::Isolate* isolate = info.GetIsolate();
 
-	V8_CHECK(info.Length() == 2, "2 args expected");
-	V8_CHECK(info[0]->IsString(), "string expected");
-	V8_CHECK(info[1]->IsFunction(), "function expected");
+	V8_CHECK(info.Length() == 1 || info.Length() == 2, "onClient expects 1 or 2 args");
+
+	std::string evName;
+	v8::Local<v8::Function> callback;
+
+	if (info.Length() == 1) {
+		V8_CHECK(info[0]->IsFunction(), "callback must be a function");
+		evName = std::string();
+		callback = info[0].As<v8::Function>();
+	}
+	else {
+		V8_CHECK(info[0]->IsString(), "eventName must be a string");
+		V8_CHECK(info[1]->IsFunction(), "callback must be a function");
+		evName = *v8::String::Utf8Value(info.GetIsolate(), info[0].As<v8::String>());
+		callback = info[1].As<v8::Function>();
+	}
 
 	V8ResourceImpl* resource = V8ResourceImpl::Get(isolate->GetEnteredContext());
 	V8_CHECK(resource, "invalid resource");
 
-	v8::String::Utf8Value evName(isolate, info[0]);
-	resource->SubscribeRemote(*evName, info[1].As<v8::Function>(), V8::SourceLocation::GetCurrent(isolate));
+	resource->SubscribeRemote(evName, callback, V8::SourceLocation::GetCurrent(isolate));
 }
 
 static void OffClient(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
 	v8::Isolate* isolate = info.GetIsolate();
 
-	V8_CHECK(info.Length() == 2, "2 args expected");
-	V8_CHECK(info[0]->IsString(), "string expected");
-	V8_CHECK(info[1]->IsFunction(), "function expected");
+	V8_CHECK(info.Length() == 1 || info.Length() == 2, "OffClient expects 1 or 2 args");
+
+	std::string evName;
+	v8::Local<v8::Function> callback;
+
+	if (info.Length() == 1) {
+		V8_CHECK(info[0]->IsFunction(), "callback must be a function");
+		evName = std::string();
+		callback = info[0].As<v8::Function>();
+	}
+	else {
+		V8_CHECK(info[0]->IsString(), "eventName must be a string");
+		V8_CHECK(info[1]->IsFunction(), "callback must be a function");
+		evName = *v8::String::Utf8Value(info.GetIsolate(), info[0].As<v8::String>());
+		callback = info[1].As<v8::Function>();
+	}
 
 	V8ResourceImpl* resource = V8ResourceImpl::Get(isolate->GetEnteredContext());
 	V8_CHECK(resource, "invalid resource");
 
-	v8::String::Utf8Value evName(isolate, info[0]);
-	resource->UnsubscribeRemote(*evName, info[1].As<v8::Function>());
+	resource->UnsubscribeRemote(evName, callback);
 }
 
 static void EmitClient(const v8::FunctionCallbackInfo<v8::Value>& info)
@@ -103,7 +127,7 @@ static void GetPlayersByName(const v8::FunctionCallbackInfo<v8::Value>& info)
 
 	alt::Array<Ref<alt::IPlayer>> players = alt::ICore::Instance().GetPlayersByName(*name);
 	v8::Local<v8::Array> arr = v8::Array::New(isolate, players.GetSize());
-	
+
 	for (uint32_t i = 0; i < players.GetSize(); ++i)
 		arr->Set(i, resource->GetBaseObjectOrNull(players[i]));
 

--- a/src/events/Main.cpp
+++ b/src/events/Main.cpp
@@ -23,7 +23,7 @@ V8::EventHandler clientScriptEvent(
 	},
 	[](V8ResourceImpl* resource, const CEvent* e, std::vector<v8::Local<v8::Value>>& args) {
 		auto ev = static_cast<const alt::CClientScriptEvent*>(e);
-
+		args.push_back(v8::String::NewFromUtf8(resource->GetIsolate(), ev->GetName().CStr()));
 		args.push_back(resource->GetBaseObjectOrNull(ev->GetTarget()));
 		V8Helpers::MValueArgsToV8(ev->GetArgs(), args);
 	}
@@ -37,6 +37,7 @@ V8::EventHandler serverScriptEvent(
 	},
 	[](V8ResourceImpl* resource, const CEvent* e, std::vector<v8::Local<v8::Value>>& args) {
 		auto ev = static_cast<const alt::CServerScriptEvent*>(e);
+		args.push_back(v8::String::NewFromUtf8(resource->GetIsolate(), ev->GetName().CStr()));
 		V8Helpers::MValueArgsToV8(ev->GetArgs(), args);
 	}
 );
@@ -53,6 +54,11 @@ V8::EventHandler colshapeEvent(
 	},
 	[](V8ResourceImpl* resource, const CEvent* e, std::vector<v8::Local<v8::Value>>& args) {
 		auto ev = static_cast<const alt::CColShapeEvent*>(e);
+
+		if (ev->GetState())
+			args.push_back(v8::String::NewFromUtf8(resource->GetIsolate(), "entityEnterColshape"));
+		else
+			args.push_back(v8::String::NewFromUtf8(resource->GetIsolate(), "entityLeaveColshape"));
 
 		args.push_back(resource->GetBaseObjectOrNull(ev->GetTarget()));
 		args.push_back(resource->GetBaseObjectOrNull(ev->GetEntity()));


### PR DESCRIPTION
Linked to https://github.com/altmp/v8-helpers/pull/11

This implements
```js
// serverside

const handler = (eventName, ...args) => {};

alt.onClient(handler)

alt.offClient(handler)
```

and update events definition that were not in v8-helpers