### PR TITLE
Add generic event handler

### DIFF
--- a/src/CNodeResourceImpl.cpp
+++ b/src/CNodeResourceImpl.cpp
@@ -180,12 +180,12 @@ bool CNodeResourceImpl::OnEvent(const alt::CEvent* e)
 			
 			if(evType == alt::CEvent::Type::SERVER_SCRIPT_EVENT) 
 			{
-				callbacks = GetLocalHandlers("*");
+				callbacks = std::move(GetLocalHandlers("*"));
 				eventName = static_cast<const alt::CServerScriptEvent*>(e)->GetName().CStr();
 			}
 			else if(evType == alt::CEvent::Type::CLIENT_SCRIPT_EVENT) 
 			{
-				callbacks = GetRemoteHandlers("*");
+				callbacks = std::move(GetRemoteHandlers("*"));
 				eventName = static_cast<const alt::CClientScriptEvent*>(e)->GetName().CStr();
 			}
 

--- a/src/CNodeResourceImpl.cpp
+++ b/src/CNodeResourceImpl.cpp
@@ -176,20 +176,26 @@ bool CNodeResourceImpl::OnEvent(const alt::CEvent* e)
 		if(evType == alt::CEvent::Type::CLIENT_SCRIPT_EVENT || evType == alt::CEvent::Type::SERVER_SCRIPT_EVENT)
 		{
 			std::vector<V8::EventCallback *> callbacks;
-			auto args = handler->GetArgs(this, e);
+			std::vector<v8::Local<v8::Value>> args;
+			const char* eventName;
 			if(evType == alt::CEvent::Type::SERVER_SCRIPT_EVENT) 
 			{
 				callbacks = GetLocalHandlers("*");
-				args.insert(args.begin(), V8_NEW_STRING(static_cast<const alt::CServerScriptEvent*>(e)->GetName().CStr()));
+				eventName = static_cast<const alt::CServerScriptEvent*>(e)->GetName().CStr();
 			}
 			else if(evType == alt::CEvent::Type::CLIENT_SCRIPT_EVENT) 
 			{
 				callbacks = GetRemoteHandlers("*");
-				args.insert(args.begin(), V8_NEW_STRING(static_cast<const alt::CClientScriptEvent*>(e)->GetName().CStr()));
+				eventName = static_cast<const alt::CClientScriptEvent*>(e)->GetName().CStr();
 			}
 
 			if(callbacks.size() != 0)
 			{
+				auto evArgs = handler->GetArgs(this, e);
+				args.reserve(evArgs.size() + 1);
+				args.push_back(V8_NEW_STRING(eventName));
+				args.insert(args.end(), evArgs.begin(), evArgs.end());
+
 				node::CallbackScope callbackScope(isolate, asyncResource.Get(isolate), asyncContext);
 				InvokeEventHandlers(e, callbacks, args);
 			}

--- a/src/CNodeResourceImpl.cpp
+++ b/src/CNodeResourceImpl.cpp
@@ -175,21 +175,24 @@ bool CNodeResourceImpl::OnEvent(const alt::CEvent* e)
 		auto evType = e->GetType();
 		if(evType == alt::CEvent::Type::CLIENT_SCRIPT_EVENT || evType == alt::CEvent::Type::SERVER_SCRIPT_EVENT)
 		{
-			std::vector<V8::EventCallback *> handlers;
+			std::vector<V8::EventCallback *> callbacks;
 			auto args = handler->GetArgs(this, e);
 			if(evType == alt::CEvent::Type::SERVER_SCRIPT_EVENT) 
 			{
-				handlers = GetLocalHandlers("*");
+				callbacks = GetLocalHandlers("*");
 				args.insert(args.begin(), V8_NEW_STRING(static_cast<const alt::CServerScriptEvent*>(e)->GetName().CStr()));
 			}
 			else if(evType == alt::CEvent::Type::CLIENT_SCRIPT_EVENT) 
 			{
-				handlers = GetRemoteHandlers("*");
+				callbacks = GetRemoteHandlers("*");
 				args.insert(args.begin(), V8_NEW_STRING(static_cast<const alt::CClientScriptEvent*>(e)->GetName().CStr()));
 			}
-			
-			node::CallbackScope callbackScope(isolate, asyncResource.Get(isolate), asyncContext);
-			InvokeEventHandlers(e, handlers, args);
+
+			if(callbacks.size() != 0)
+			{
+				node::CallbackScope callbackScope(isolate, asyncResource.Get(isolate), asyncContext);
+				InvokeEventHandlers(e, callbacks, args);
+			}
 		}
 	}
 

--- a/src/CNodeResourceImpl.cpp
+++ b/src/CNodeResourceImpl.cpp
@@ -180,12 +180,12 @@ bool CNodeResourceImpl::OnEvent(const alt::CEvent* e)
 			
 			if(evType == alt::CEvent::Type::SERVER_SCRIPT_EVENT) 
 			{
-				callbacks = std::move(GetLocalHandlers("*"));
+				callbacks = std::move(GetGenericHandlers(true));
 				eventName = static_cast<const alt::CServerScriptEvent*>(e)->GetName().CStr();
 			}
 			else if(evType == alt::CEvent::Type::CLIENT_SCRIPT_EVENT) 
 			{
-				callbacks = std::move(GetRemoteHandlers("*"));
+				callbacks = std::move(GetGenericHandlers(false));
 				eventName = static_cast<const alt::CClientScriptEvent*>(e)->GetName().CStr();
 			}
 

--- a/src/CNodeResourceImpl.cpp
+++ b/src/CNodeResourceImpl.cpp
@@ -176,8 +176,8 @@ bool CNodeResourceImpl::OnEvent(const alt::CEvent* e)
 		if(evType == alt::CEvent::Type::CLIENT_SCRIPT_EVENT || evType == alt::CEvent::Type::SERVER_SCRIPT_EVENT)
 		{
 			std::vector<V8::EventCallback *> callbacks;
-			std::vector<v8::Local<v8::Value>> args;
 			const char* eventName;
+			
 			if(evType == alt::CEvent::Type::SERVER_SCRIPT_EVENT) 
 			{
 				callbacks = GetLocalHandlers("*");
@@ -192,12 +192,10 @@ bool CNodeResourceImpl::OnEvent(const alt::CEvent* e)
 			if(callbacks.size() != 0)
 			{
 				auto evArgs = handler->GetArgs(this, e);
-				args.reserve(evArgs.size() + 1);
-				args.push_back(V8_NEW_STRING(eventName));
-				args.insert(args.end(), evArgs.begin(), evArgs.end());
+				evArgs.insert(evArgs.begin(), V8_NEW_STRING(eventName));
 
 				node::CallbackScope callbackScope(isolate, asyncResource.Get(isolate), asyncContext);
-				InvokeEventHandlers(e, callbacks, args);
+				InvokeEventHandlers(e, callbacks, evArgs);
 			}
 		}
 	}

--- a/src/bindings/Main.cpp
+++ b/src/bindings/Main.cpp
@@ -8,34 +8,61 @@ using namespace alt;
 static void OnClient(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
 	V8_GET_ISOLATE_CONTEXT_RESOURCE();
-	V8_CHECK_ARGS_LEN(2);
+	V8_CHECK_ARGS_LEN2(1, 2);
 
-	V8_ARG_TO_STRING(1, eventName);
-	V8_ARG_TO_FUNCTION(2, callback);
+	if(info.Length() == 1)
+	{
+		V8_ARG_TO_FUNCTION(1, callback);
 
-	resource->SubscribeRemote(eventName.ToString(), callback, V8::SourceLocation::GetCurrent(isolate));
+		resource->SubscribeGeneric(false, callback, V8::SourceLocation::GetCurrent(isolate));
+	}
+	else if(info.Length() == 2)
+	{
+		V8_ARG_TO_STRING(1, eventName);
+		V8_ARG_TO_FUNCTION(2, callback);
+
+		resource->SubscribeRemote(eventName.ToString(), callback, V8::SourceLocation::GetCurrent(isolate));
+	}
 }
 
 static void OnceClient(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
 	V8_GET_ISOLATE_CONTEXT_RESOURCE();
-	V8_CHECK_ARGS_LEN(2);
+	V8_CHECK_ARGS_LEN2(1, 2);
 
-	V8_ARG_TO_STRING(1, eventName);
-	V8_ARG_TO_FUNCTION(2, callback);
+	if(info.Length() == 1)
+	{
+		V8_ARG_TO_FUNCTION(1, callback);
 
-	resource->SubscribeRemote(eventName.ToString(), callback, V8::SourceLocation::GetCurrent(isolate), true);
+		resource->SubscribeGeneric(false, callback, V8::SourceLocation::GetCurrent(isolate), true);
+	}
+	else if(info.Length() == 2)
+	{
+		V8_ARG_TO_STRING(1, eventName);
+		V8_ARG_TO_FUNCTION(2, callback);
+
+		resource->SubscribeRemote(eventName.ToString(), callback, V8::SourceLocation::GetCurrent(isolate), true);
+	}
 }
 
 static void OffClient(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
 	V8_GET_ISOLATE_CONTEXT_RESOURCE();
-	V8_CHECK_ARGS_LEN(2);
+	V8_CHECK_ARGS_LEN2(1, 2);
 
-	V8_ARG_TO_STRING(1, eventName);
-	V8_ARG_TO_FUNCTION(2, callback);
+	if(info.Length() == 1)
+	{
+		V8_ARG_TO_FUNCTION(1, callback);
 
-	resource->UnsubscribeRemote(eventName.ToString(), callback);
+		resource->UnsubscribeGeneric(true, callback);
+	}
+	else if(info.Length() == 2)
+	{
+		V8_ARG_TO_STRING(1, evName);
+		V8_ARG_TO_FUNCTION(2, callback);
+
+		resource->UnsubscribeRemote(evName.ToString(), callback);
+	}
 }
 
 static void EmitClient(const v8::FunctionCallbackInfo<v8::Value>& info)

--- a/src/bindings/Main.cpp
+++ b/src/bindings/Main.cpp
@@ -14,7 +14,7 @@ static void OnClient(const v8::FunctionCallbackInfo<v8::Value>& info)
 	{
 		V8_ARG_TO_FUNCTION(1, callback);
 
-		resource->SubscribeGeneric(false, callback, V8::SourceLocation::GetCurrent(isolate));
+		resource->SubscribeGenericRemote(callback, V8::SourceLocation::GetCurrent(isolate));
 	}
 	else if(info.Length() == 2)
 	{
@@ -34,7 +34,7 @@ static void OnceClient(const v8::FunctionCallbackInfo<v8::Value>& info)
 	{
 		V8_ARG_TO_FUNCTION(1, callback);
 
-		resource->SubscribeGeneric(false, callback, V8::SourceLocation::GetCurrent(isolate), true);
+		resource->SubscribeGenericRemote(callback, V8::SourceLocation::GetCurrent(isolate), true);
 	}
 	else if(info.Length() == 2)
 	{
@@ -54,7 +54,7 @@ static void OffClient(const v8::FunctionCallbackInfo<v8::Value>& info)
 	{
 		V8_ARG_TO_FUNCTION(1, callback);
 
-		resource->UnsubscribeGeneric(true, callback);
+		resource->UnsubscribeGenericRemote(callback);
 	}
 	else if(info.Length() == 2)
 	{


### PR DESCRIPTION
Example:
```js
alt.on((name, ...args) => {});
alt.onClient((name, player, ...args) => {});
```
This could possible integrated with the events system better but eh. This approach works just fine, and doesn't need a whole rewrite of the event system in JS module.

Related to https://github.com/altmp/altv-issues/issues/864

Needs https://github.com/altmp/v8-helpers/pull/27