### PR TITLE
Add sending raw values in events

### DIFF
--- a/client/src/bindings/Main.cpp
+++ b/client/src/bindings/Main.cpp
@@ -83,6 +83,20 @@ static void EmitServer(const v8::FunctionCallbackInfo<v8::Value>& info)
     alt::ICore::Instance().TriggerServerEvent(eventName.ToString(), args);
 }
 
+static void EmitServerRaw(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+    V8_GET_ISOLATE_CONTEXT_RESOURCE();
+
+    V8_CHECK_ARGS_LEN_MIN(1);
+    V8_ARG_TO_STRING(1, eventName);
+
+    alt::MValueArgs args;
+
+    for(int i = 1; i < info.Length(); ++i) args.Push(V8Helpers::V8ToRawBytes(info[i]));
+
+    alt::ICore::Instance().TriggerServerEvent(eventName.ToString(), args);
+}
+
 static void GameControlsEnabled(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
     V8_GET_ISOLATE();
@@ -887,6 +901,7 @@ extern V8Module altModule("alt",
                               V8Helpers::RegisterFunc(exports, "onceServer", &OnceServer);
                               V8Helpers::RegisterFunc(exports, "offServer", &OffServer);
                               V8Helpers::RegisterFunc(exports, "emitServer", &EmitServer);
+                              V8Helpers::RegisterFunc(exports, "emitServerRaw", &EmitServerRaw);
                               V8Helpers::RegisterFunc(exports, "gameControlsEnabled", &GameControlsEnabled);
                               V8Helpers::RegisterFunc(exports, "toggleGameControls", &ToggleGameControls);
                               V8Helpers::RegisterFunc(exports, "toggleVoiceControls", &ToggleVoiceControls);

--- a/server/src/bindings/Main.cpp
+++ b/server/src/bindings/Main.cpp
@@ -126,6 +126,67 @@ static void EmitAllClients(const v8::FunctionCallbackInfo<v8::Value>& info)
     ICore::Instance().TriggerClientEventForAll(eventName, args);
 }
 
+static void EmitClientRaw(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+    V8_GET_ISOLATE_CONTEXT();
+    V8_CHECK_ARGS_LEN_MIN(2);
+
+    V8_ARG_TO_STRING(2, eventName);
+
+    MValueArgs mvArgs;
+
+    for(int i = 2; i < info.Length(); ++i) mvArgs.Push(V8Helpers::V8ToRawBytes(info[i]));
+
+    if(info[0]->IsNull())
+    {
+        // if first argument is null this event gets send to every player
+        ICore::Instance().TriggerClientEventForAll(eventName.ToString(), mvArgs);
+        return;
+    }
+
+    if(info[0]->IsArray())
+    {
+        // if first argument is an array of players this event will be sent to every player in array
+        v8::Local<v8::Array> arr = info[0].As<v8::Array>();
+        Array<Ref<IPlayer>> targets;
+        targets.Reserve(arr->Length());
+
+        for(int i = 0; i < arr->Length(); ++i)
+        {
+            Ref<IPlayer> player;
+            v8::Local<v8::Value> ply;
+            V8_CHECK(arr->Get(ctx, i).ToLocal(&ply), "Invalid player in emitClient players array");
+            V8Entity* v8Player = V8Entity::Get(ply);
+
+            V8_CHECK(v8Player && v8Player->GetHandle()->GetType() == alt::IBaseObject::Type::PLAYER, "player inside array expected");
+            targets.Push(v8Player->GetHandle().As<IPlayer>());
+        }
+
+        ICore::Instance().TriggerClientEvent(targets, eventName.ToString(), mvArgs);
+    }
+    else
+    {
+        // if first argument is not null and not an array this event gets sent to the specific player
+        V8Entity* v8Player = V8Entity::Get(info[0]);
+        V8_CHECK(v8Player && v8Player->GetHandle()->GetType() == alt::IBaseObject::Type::PLAYER, "player or null expected");
+
+        ICore::Instance().TriggerClientEvent(v8Player->GetHandle().As<IPlayer>(), eventName.ToString(), mvArgs);
+    }
+}
+
+static void EmitAllClientsRaw(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+    V8_GET_ISOLATE_CONTEXT();
+    V8_CHECK_ARGS_LEN_MIN(1);
+    V8_ARG_TO_STRING(1, eventName);
+
+    MValueArgs args;
+
+    for(int i = 1; i < info.Length(); ++i) args.Push(V8Helpers::V8ToRawBytes(info[i]));
+
+    ICore::Instance().TriggerClientEventForAll(eventName, args);
+}
+
 static void SetSyncedMeta(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
     V8_GET_ISOLATE_CONTEXT();
@@ -239,40 +300,55 @@ static void GetResourceExports(const v8::FunctionCallbackInfo<v8::Value>& info)
     }
 }
 
-extern V8Class v8Player, v8Vehicle, v8Blip, v8AreaBlip, v8RadiusBlip, v8PointBlip, v8Checkpoint, v8VoiceChannel, v8Colshape, v8ColshapeCylinder, v8ColshapeSphere, v8ColshapeCircle, v8ColshapeCuboid,
-  v8ColshapeRectangle;
+extern V8Class v8Player, v8Vehicle, v8Blip, v8AreaBlip, v8RadiusBlip, v8PointBlip, v8Checkpoint, v8VoiceChannel, v8Colshape, v8ColshapeCylinder, v8ColshapeSphere, v8ColshapeCircle,
+  v8ColshapeCuboid, v8ColshapeRectangle;
 
 extern V8Module sharedModule;
 
-extern V8Module
-  v8Alt("alt",
-        &sharedModule,
-        { v8Player, v8Vehicle, v8Blip, v8AreaBlip, v8RadiusBlip, v8PointBlip, v8Checkpoint, v8RadiusBlip, v8VoiceChannel, v8Colshape, v8ColshapeCylinder, v8ColshapeSphere, v8ColshapeCircle, v8ColshapeCuboid, v8ColshapeRectangle },
-        [](v8::Local<v8::Context> ctx, v8::Local<v8::Object> exports) {
-            v8::Isolate* isolate = ctx->GetIsolate();
+extern V8Module v8Alt("alt",
+                      &sharedModule,
+                      { v8Player,
+                        v8Vehicle,
+                        v8Blip,
+                        v8AreaBlip,
+                        v8RadiusBlip,
+                        v8PointBlip,
+                        v8Checkpoint,
+                        v8RadiusBlip,
+                        v8VoiceChannel,
+                        v8Colshape,
+                        v8ColshapeCylinder,
+                        v8ColshapeSphere,
+                        v8ColshapeCircle,
+                        v8ColshapeCuboid,
+                        v8ColshapeRectangle },
+                      [](v8::Local<v8::Context> ctx, v8::Local<v8::Object> exports) {
+                          v8::Isolate* isolate = ctx->GetIsolate();
 
-            V8Helpers::RegisterFunc(exports, "getResourceMain", &GetResourceMain);
-            V8Helpers::RegisterFunc(exports, "getResourcePath", &GetResourcePath);
-            V8Helpers::RegisterFunc(exports, "getResourceExports", &GetResourceExports);
+                          V8Helpers::RegisterFunc(exports, "getResourceMain", &GetResourceMain);
+                          V8Helpers::RegisterFunc(exports, "getResourcePath", &GetResourcePath);
+                          V8Helpers::RegisterFunc(exports, "getResourceExports", &GetResourceExports);
 
-            V8Helpers::RegisterFunc(exports, "startResource", &StartResource);
-            V8Helpers::RegisterFunc(exports, "stopResource", &StopResource);
-            V8Helpers::RegisterFunc(exports, "restartResource", &RestartResource);
+                          V8Helpers::RegisterFunc(exports, "startResource", &StartResource);
+                          V8Helpers::RegisterFunc(exports, "stopResource", &StopResource);
+                          V8Helpers::RegisterFunc(exports, "restartResource", &RestartResource);
 
-            V8Helpers::RegisterFunc(exports, "onClient", &OnClient);
-            V8Helpers::RegisterFunc(exports, "onceClient", &OnceClient);
-            V8Helpers::RegisterFunc(exports, "offClient", &OffClient);
-            V8Helpers::RegisterFunc(exports, "emitClient", &EmitClient);
-            V8Helpers::RegisterFunc(exports, "emitAllClients", &EmitAllClients);
+                          V8Helpers::RegisterFunc(exports, "onClient", &OnClient);
+                          V8Helpers::RegisterFunc(exports, "onceClient", &OnceClient);
+                          V8Helpers::RegisterFunc(exports, "offClient", &OffClient);
+                          V8Helpers::RegisterFunc(exports, "emitClient", &EmitClient);
+                          V8Helpers::RegisterFunc(exports, "emitAllClients", &EmitAllClients);
+                          V8Helpers::RegisterFunc(exports, "emitClientRaw", &EmitClientRaw);
+                          V8Helpers::RegisterFunc(exports, "emitAllClientsRaw", &EmitAllClientsRaw);
 
-            V8Helpers::RegisterFunc(exports, "setSyncedMeta", &SetSyncedMeta);
-            V8Helpers::RegisterFunc(exports, "deleteSyncedMeta", &DeleteSyncedMeta);
+                          V8Helpers::RegisterFunc(exports, "setSyncedMeta", &SetSyncedMeta);
+                          V8Helpers::RegisterFunc(exports, "deleteSyncedMeta", &DeleteSyncedMeta);
 
-            V8Helpers::RegisterFunc(exports, "getNetTime", &GetNetTime);
+                          V8Helpers::RegisterFunc(exports, "getNetTime", &GetNetTime);
 
-            V8Helpers::RegisterFunc(exports, "setPassword", &SetPassword);
+                          V8Helpers::RegisterFunc(exports, "setPassword", &SetPassword);
 
-            V8_OBJECT_SET_STRING(exports, "rootDir", alt::ICore::Instance().GetRootDirectory());
-            V8_OBJECT_SET_INT(exports, "defaultDimension", alt::DEFAULT_DIMENSION);
-            V8_OBJECT_SET_INT(exports, "globalDimension", alt::GLOBAL_DIMENSION);
-        });
+                          V8_OBJECT_SET_STRING(exports, "rootDir", alt::ICore::Instance().GetRootDirectory());
+                          V8_OBJECT_SET_INT(exports, "defaultDimension", alt::DEFAULT_DIMENSION);
+                          V8_OBJECT_SET_INT(exports, "globalDimension", alt::GLOBAL_DIMENSION);
+                      });

--- a/shared/V8Helpers.cpp
+++ b/shared/V8Helpers.cpp
@@ -468,7 +468,7 @@ v8::MaybeLocal<v8::Value> V8Helpers::RawBytesToV8(alt::MValueByteArrayConst rawB
         if(bytes[i] != magicBytes[i]) return v8::MaybeLocal<v8::Value>();
     }
 
-    // Remove the magic bytes + type from the byte array
+    // Remove the magic bytes from the byte array
     bytes.erase(bytes.begin(), bytes.begin() + sizeof(magicBytes));
 
     v8::Isolate* isolate = v8::Isolate::GetCurrent();

--- a/shared/V8Helpers.cpp
+++ b/shared/V8Helpers.cpp
@@ -516,11 +516,14 @@ v8::MaybeLocal<v8::Value> V8Helpers::RawBytesToV8(alt::MValueByteArrayConst rawB
         }
         case RawValueType::RGBA:
         {
-            uint8_t r, g, b, a;
-            if(!deserializer.ReadRawBytes(sizeof(uint8_t), (const void**)&r) || !deserializer.ReadRawBytes(sizeof(uint8_t), (const void**)&g) ||
-               !deserializer.ReadRawBytes(sizeof(uint8_t), (const void**)&b) || !deserializer.ReadRawBytes(sizeof(uint8_t), (const void**)&a))
+            uint8_t* rPtr;
+            uint8_t* gPtr;
+            uint8_t* bPtr;
+            uint8_t* aPtr;
+            if(!deserializer.ReadRawBytes(sizeof(uint8_t), (const void**)&rPtr) || !deserializer.ReadRawBytes(sizeof(uint8_t), (const void**)&gPtr) ||
+               !deserializer.ReadRawBytes(sizeof(uint8_t), (const void**)&bPtr) || !deserializer.ReadRawBytes(sizeof(uint8_t), (const void**)&aPtr))
                 return v8::MaybeLocal<v8::Value>();
-            result = resource->CreateRGBA({ r, g, b, a });
+            result = resource->CreateRGBA({ *rPtr, *gPtr, *bPtr, *aPtr });
             break;
         }
     }

--- a/shared/V8Helpers.h
+++ b/shared/V8Helpers.h
@@ -375,13 +375,13 @@ namespace V8
 
         // Serializes a JS value to a binary format
         // Make sure the context is entered before calling this function
-        inline Value Serialize(v8::Local<v8::Context> context, v8::Local<v8::Value> value)
+        inline Value Serialize(v8::Local<v8::Context> context, v8::Local<v8::Value> value, bool ownPtr = true)
         {
             v8::ValueSerializer serializer(context->GetIsolate());
             serializer.WriteHeader();
             if(serializer.WriteValue(context, value).IsNothing()) return Value{};
             std::pair<uint8_t*, size_t> data = serializer.Release();
-            return Value{ data.first, data.second };
+            return Value{ data.first, data.second, ownPtr };
         }
 
         // Deserializes a JS value from a binary format

--- a/shared/V8Helpers.h
+++ b/shared/V8Helpers.h
@@ -71,6 +71,9 @@ namespace V8Helpers
 
     void SetAccessor(v8::Local<v8::Template> tpl, v8::Isolate* isolate, const char* name, v8::AccessorGetterCallback getter, v8::AccessorSetterCallback setter = nullptr);
 
+    alt::MValueByteArray V8ToRawBytes(v8::Local<v8::Value> val);
+    v8::MaybeLocal<v8::Value> RawBytesToV8(alt::MValueByteArrayConst bytes);
+
 };  // namespace V8Helpers
 
 class V8ResourceImpl;
@@ -355,18 +358,18 @@ namespace V8
         {
             uint8_t* data;
             size_t size;
+            bool ownPtr;  // If true, the data pointer is owned by this object and must be freed when this object is destroyed
 
             bool Valid() const
             {
                 return data != nullptr && size > 0;
             }
 
-            Value() : data(nullptr), size(0) {}
-            Value(uint8_t* data, size_t size) : data(data), size(size) {}
+            Value() : data(nullptr), size(0), ownPtr(false) {}
+            Value(uint8_t* data, size_t size, bool ownPtr = true) : data(data), size(size), ownPtr(ownPtr) {}
             ~Value()
             {
-                // Make sure we free the data here, because V8 transfered ownership of the data to us
-                free(data);
+                if(ownPtr) free(data);
             }
         };
 


### PR DESCRIPTION
This adds new functions to send raw values in events from and to JavaScript resources. Works both on the server and client.
Does **NOT** work with e.g. C# module

This serializes the value into a raw buffer instead of a MValue, which is a lot faster, but loses the compatibility across languages, so this only works when sending from JS to JS.