### PR TITLE
Implements webview events queue

### DIFF
--- a/client/src/CV8Resource.cpp
+++ b/client/src/CV8Resource.cpp
@@ -420,4 +420,4 @@ void CV8ResourceImpl::HandleWebViewEventQueue(const alt::Ref<alt::IWebView> view
         view->Trigger(evName, mvArgs);
         eventQueue.pop();
     }
-} 
+}

--- a/client/src/CV8Resource.cpp
+++ b/client/src/CV8Resource.cpp
@@ -289,11 +289,14 @@ bool CV8ResourceImpl::OnEvent(const alt::CEvent* e)
         {
             CV8ScriptRuntime::Instance().resourcesLoaded = false;
         }
-        else if(e->GetType() == alt::CEvent::Type::WEB_VIEW_EVENT)
+    }
+
+    {
+        if(e->GetType() == alt::CEvent::Type::WEB_VIEW_EVENT)
         {
             auto ev = static_cast<const alt::CWebViewEvent*>(e);
             if (ev->GetName() == "load")
-                this->HandleWebViewEventQueue(ev->GetTarget());
+                HandleWebViewEventQueue(ev->GetTarget());
         }
     }
 

--- a/client/src/CV8Resource.cpp
+++ b/client/src/CV8Resource.cpp
@@ -423,6 +423,5 @@ void CV8ResourceImpl::HandleWebViewEventQueue(const alt::Ref<alt::IWebView> view
         view->Trigger(evName, mvArgs);
     }
 
-    eventQueue.clear();
     eventQueuesMap.erase(view);
 }

--- a/client/src/CV8Resource.cpp
+++ b/client/src/CV8Resource.cpp
@@ -289,6 +289,11 @@ bool CV8ResourceImpl::OnEvent(const alt::CEvent* e)
         {
             CV8ScriptRuntime::Instance().resourcesLoaded = false;
         }
+        else if(e->GetType() == alt::CEvent::Type::WEB_VIEW_EVENT)
+        {
+            if (static_cast<const alt::CWebViewEvent*>(e)->GetName() == "load")
+                this->HandleWebViewsEventQueue();
+        }
     }
 
     return true;
@@ -402,3 +407,18 @@ void CV8ResourceImpl::RemoveWorker(CWorker* worker)
 {
     workers.erase(worker);
 }
+
+void CV8ResourceImpl::HandleWebViewsEventQueue()
+{
+    for (auto& [view, eventQueue]: webViewsEventsQueue)
+    {
+        if (eventQueue.empty()) continue;
+
+        while (!eventQueue.empty())
+        {
+            auto& [evName, mvArgs] = eventQueue.front();
+            view->Trigger(evName, mvArgs);
+            eventQueue.pop();
+        }
+    }
+} 

--- a/client/src/CV8Resource.cpp
+++ b/client/src/CV8Resource.cpp
@@ -418,7 +418,7 @@ void CV8ResourceImpl::HandleWebViewEventQueue(const alt::Ref<alt::IWebView> view
     auto& eventQueue = eventQueuesMap[view];
     if (eventQueue.empty()) return;
 
-    for (auto& [evName, mvArgs]: eventQueue)
+    for (auto& [evName, mvArgs] : eventQueue)
     {
         view->Trigger(evName, mvArgs);
     }

--- a/client/src/CV8Resource.cpp
+++ b/client/src/CV8Resource.cpp
@@ -291,8 +291,9 @@ bool CV8ResourceImpl::OnEvent(const alt::CEvent* e)
         }
         else if(e->GetType() == alt::CEvent::Type::WEB_VIEW_EVENT)
         {
-            if (static_cast<const alt::CWebViewEvent*>(e)->GetName() == "load")
-                this->HandleWebViewsEventQueue();
+            auto ev = static_cast<const alt::CWebViewEvent*>(e);
+            if (ev->GetName() == "load")
+                this->HandleWebViewEventQueue(ev->GetTarget());
         }
     }
 
@@ -408,17 +409,15 @@ void CV8ResourceImpl::RemoveWorker(CWorker* worker)
     workers.erase(worker);
 }
 
-void CV8ResourceImpl::HandleWebViewsEventQueue()
+void CV8ResourceImpl::HandleWebViewEventQueue(const alt::Ref<alt::IWebView> view)
 {
-    for (auto& [view, eventQueue]: webViewsEventsQueue)
-    {
-        if (eventQueue.empty()) continue;
+    auto& eventQueue = this->GetWebviewEventQueue(view);
+    if (eventQueue.empty()) return;
 
-        while (!eventQueue.empty())
-        {
-            auto& [evName, mvArgs] = eventQueue.front();
-            view->Trigger(evName, mvArgs);
-            eventQueue.pop();
-        }
+    while (!eventQueue.empty())
+    {
+        auto& [evName, mvArgs] = eventQueue.front();
+        view->Trigger(evName, mvArgs);
+        eventQueue.pop();
     }
 } 

--- a/client/src/CV8Resource.cpp
+++ b/client/src/CV8Resource.cpp
@@ -415,7 +415,9 @@ void CV8ResourceImpl::RemoveWorker(CWorker* worker)
 void CV8ResourceImpl::HandleWebViewEventQueue(const alt::Ref<alt::IWebView> view)
 {
     auto& eventQueuesMap = this->GetWebviewsEventQueue();
-    auto& eventQueue = eventQueuesMap[view];
+    if (!eventQueuesMap.count(view)) return;
+
+    auto& eventQueue = eventQueuesMap.at(view);
     if (eventQueue.empty()) return;
 
     for (auto& [evName, mvArgs] : eventQueue)

--- a/client/src/CV8Resource.cpp
+++ b/client/src/CV8Resource.cpp
@@ -414,13 +414,15 @@ void CV8ResourceImpl::RemoveWorker(CWorker* worker)
 
 void CV8ResourceImpl::HandleWebViewEventQueue(const alt::Ref<alt::IWebView> view)
 {
-    auto& eventQueue = this->GetWebviewEventQueue(view);
+    auto& eventQueuesMap = this->GetWebviewsEventQueue();
+    auto& eventQueue = eventQueuesMap[view];
     if (eventQueue.empty()) return;
 
-    while (!eventQueue.empty())
+    for (auto& [evName, mvArgs]: eventQueue)
     {
-        auto& [evName, mvArgs] = eventQueue.front();
         view->Trigger(evName, mvArgs);
-        eventQueue.pop();
     }
+
+    eventQueue.clear();
+    eventQueuesMap.erase(view);
 }

--- a/client/src/CV8Resource.h
+++ b/client/src/CV8Resource.h
@@ -137,12 +137,19 @@ public:
         return workers.size();
     }
 
+    void HandleWebViewsEventQueue();
+    std::queue<std::pair<alt::String, alt::MValueArgs>>& GetWebviewEventQueue(const alt::Ref<alt::IWebView>& view)
+    {
+        return webViewsEventsQueue[view];
+    }
 private:
     using WebViewEvents = std::unordered_multimap<std::string, V8::EventCallback>;
 
     std::unordered_map<alt::Ref<alt::IWebView>, WebViewEvents> webViewHandlers;
     std::unordered_map<alt::Ref<alt::IWebSocketClient>, WebViewEvents> webSocketClientHandlers;
     std::unordered_map<alt::Ref<alt::IAudio>, WebViewEvents> audioHandlers;
+
+    std::unordered_map<alt::Ref<alt::IWebView>, std::queue<std::pair<alt::String, alt::MValueArgs>>> webViewsEventsQueue;
 
     std::unordered_set<alt::Ref<alt::IBaseObject>> ownedObjects;
 

--- a/client/src/CV8Resource.h
+++ b/client/src/CV8Resource.h
@@ -137,10 +137,9 @@ public:
         return workers.size();
     }
 
-    void HandleWebViewEventQueue(const alt::Ref<alt::IWebView> view);
-    std::queue<std::pair<alt::String, alt::MValueArgs>>& GetWebviewEventQueue(const alt::Ref<alt::IWebView>& view)
+    void AddWebViewEventToQueue(const alt::Ref<alt::IWebView> view, const alt::String& evName, const alt::MValueArgs& mvArgs)
     {
-        return webViewsEventsQueue[view];
+        webViewsEventsQueue[view].push_back(std::pair(evName, mvArgs));
     }
 private:
     using WebViewEvents = std::unordered_multimap<std::string, V8::EventCallback>;
@@ -149,7 +148,12 @@ private:
     std::unordered_map<alt::Ref<alt::IWebSocketClient>, WebViewEvents> webSocketClientHandlers;
     std::unordered_map<alt::Ref<alt::IAudio>, WebViewEvents> audioHandlers;
 
-    std::unordered_map<alt::Ref<alt::IWebView>, std::queue<std::pair<alt::String, alt::MValueArgs>>> webViewsEventsQueue;
+    std::unordered_map<alt::Ref<alt::IWebView>, std::vector<std::pair<alt::String, alt::MValueArgs>>> webViewsEventsQueue;
+    std::unordered_map<alt::Ref<alt::IWebView>, std::vector<std::pair<alt::String, alt::MValueArgs>>>& GetWebviewsEventQueue()
+    {
+        return webViewsEventsQueue;
+    }
+    void HandleWebViewEventQueue(const alt::Ref<alt::IWebView> view);
 
     std::unordered_set<alt::Ref<alt::IBaseObject>> ownedObjects;
 

--- a/client/src/CV8Resource.h
+++ b/client/src/CV8Resource.h
@@ -137,7 +137,7 @@ public:
         return workers.size();
     }
 
-    void HandleWebViewsEventQueue();
+    void HandleWebViewEventQueue(const alt::Ref<alt::IWebView> view);
     std::queue<std::pair<alt::String, alt::MValueArgs>>& GetWebviewEventQueue(const alt::Ref<alt::IWebView>& view)
     {
         return webViewsEventsQueue[view];

--- a/client/src/CV8Resource.h
+++ b/client/src/CV8Resource.h
@@ -143,13 +143,14 @@ public:
     }
 private:
     using WebViewEvents = std::unordered_multimap<std::string, V8::EventCallback>;
+    using WebViewsEventsQueue = std::unordered_map<alt::Ref<alt::IWebView>, std::vector<std::pair<alt::String, alt::MValueArgs>>>;
 
     std::unordered_map<alt::Ref<alt::IWebView>, WebViewEvents> webViewHandlers;
     std::unordered_map<alt::Ref<alt::IWebSocketClient>, WebViewEvents> webSocketClientHandlers;
     std::unordered_map<alt::Ref<alt::IAudio>, WebViewEvents> audioHandlers;
 
-    std::unordered_map<alt::Ref<alt::IWebView>, std::vector<std::pair<alt::String, alt::MValueArgs>>> webViewsEventsQueue;
-    std::unordered_map<alt::Ref<alt::IWebView>, std::vector<std::pair<alt::String, alt::MValueArgs>>>& GetWebviewsEventQueue()
+    WebViewsEventsQueue webViewsEventsQueue;
+    WebViewsEventsQueue& GetWebviewsEventQueue()
     {
         return webViewsEventsQueue;
     }

--- a/client/src/bindings/WebView.cpp
+++ b/client/src/bindings/WebView.cpp
@@ -74,7 +74,10 @@ static void Emit(const v8::FunctionCallbackInfo<v8::Value>& info)
 
     for(int i = 1; i < info.Length(); ++i) mvArgs.Push(V8Helpers::V8ToMValue(info[i], false));
 
-    view->Trigger(evName, mvArgs);
+    if (!view->IsReady())
+        static_cast<CV8ResourceImpl*>(resource)->GetWebviewEventQueue(view).push(std::pair(evName, mvArgs));
+    else
+        view->Trigger(evName, mvArgs);
 }
 
 static void GetEventListeners(const v8::FunctionCallbackInfo<v8::Value>& info)

--- a/client/src/bindings/WebView.cpp
+++ b/client/src/bindings/WebView.cpp
@@ -75,7 +75,7 @@ static void Emit(const v8::FunctionCallbackInfo<v8::Value>& info)
     for(int i = 1; i < info.Length(); ++i) mvArgs.Push(V8Helpers::V8ToMValue(info[i], false));
 
     if (!view->IsReady())
-        static_cast<CV8ResourceImpl*>(resource)->GetWebviewEventQueue(view).push(std::pair(evName, mvArgs));
+        static_cast<CV8ResourceImpl*>(resource)->AddWebViewEventToQueue(view, evName, mvArgs);
     else
         view->Trigger(evName, mvArgs);
 }


### PR DESCRIPTION
With this feature the events are pushed into a queue when the Webview is not ready, allowing you to emit right after creating a Webview.

Example
```js
const view = new alt.Webview('http://assets/web/index.html');
view.emit('test');
```

The test event will be enqueued and resumed once on the Webview load event is fired