### PR TITLE
Fix for lost WebView events

### DIFF
--- a/client/src/CV8Resource.cpp
+++ b/client/src/CV8Resource.cpp
@@ -417,16 +417,13 @@ void CV8ResourceImpl::RemoveWorker(CWorker* worker)
 
 void CV8ResourceImpl::HandleWebViewEventQueue(const alt::Ref<alt::IWebView> view)
 {
-    auto& eventQueuesMap = this->GetWebviewsEventQueue();
-    if(!eventQueuesMap.count(view)) return;
+    auto eventQueue = webViewsEventsQueue.find(view);
+    if (eventQueue == webViewsEventsQueue.end()) return;
 
-    auto& eventQueue = eventQueuesMap.at(view);
-    if(eventQueue.empty()) return;
-
-    for(auto& [evName, mvArgs] : eventQueue)
+    for(auto& [evName, mvArgs] : eventQueue->second)
     {
         view->Trigger(evName, mvArgs);
     }
 
-    eventQueuesMap.erase(view);
+    webViewsEventsQueue.erase(eventQueue);
 }

--- a/client/src/CV8Resource.h
+++ b/client/src/CV8Resource.h
@@ -134,9 +134,19 @@ public:
     void AddWorker(CWorker* worker);
     void RemoveWorker(CWorker* worker);
 
-    void AddWebViewEventToQueue(const alt::Ref<alt::IWebView> view, const alt::String& evName, const alt::MValueArgs& mvArgs)
+    void InitWebViewEventQueue(const alt::Ref<alt::IWebView> view)
     {
-        webViewsEventsQueue[view].push_back(std::pair(evName, mvArgs));
+        webViewsEventsQueue[view] = {};
+    }
+    bool TryAddWebViewEventToQueue(const alt::Ref<alt::IWebView> view, const alt::String& evName, const alt::MValueArgs& mvArgs)
+    {
+        auto eventQueue = webViewsEventsQueue.find(view);
+        if (eventQueue != webViewsEventsQueue.end())
+        {
+            eventQueue->second.emplace_back(evName, mvArgs);
+            return true;
+        }
+        return false;
     }
 
 private:
@@ -148,10 +158,6 @@ private:
     std::unordered_map<alt::Ref<alt::IAudio>, WebViewEvents> audioHandlers;
 
     WebViewsEventsQueue webViewsEventsQueue;
-    WebViewsEventsQueue& GetWebviewsEventQueue()
-    {
-        return webViewsEventsQueue;
-    }
     void HandleWebViewEventQueue(const alt::Ref<alt::IWebView> view);
 
     std::unordered_set<alt::Ref<alt::IBaseObject>> ownedObjects;

--- a/client/src/bindings/WebView.cpp
+++ b/client/src/bindings/WebView.cpp
@@ -74,9 +74,7 @@ static void Emit(const v8::FunctionCallbackInfo<v8::Value>& info)
 
     for(int i = 1; i < info.Length(); ++i) mvArgs.Push(V8Helpers::V8ToMValue(info[i], false));
 
-    if (!view->IsReady())
-        static_cast<CV8ResourceImpl*>(resource)->AddWebViewEventToQueue(view, evName, mvArgs);
-    else
+    if (!static_cast<CV8ResourceImpl*>(resource)->TryAddWebViewEventToQueue(view, evName, mvArgs))
         view->Trigger(evName, mvArgs);
 }
 
@@ -191,6 +189,8 @@ static void Constructor(const v8::FunctionCallbackInfo<v8::Value>& info)
     {
         view = alt::ICore::Instance().CreateWebView(altres, url, { 0, 0 }, { 0, 0 }, true, false);
     }
+
+    static_cast<CV8ResourceImpl*>(resource)->InitWebViewEventQueue(view);
 
     V8_BIND_BASE_OBJECT(view, "Failed to create WebView");
 }


### PR DESCRIPTION
This should prevent WebView events getting lost when a WebView is ready but not fully loaded yet (see issue #98).

Note that I was not able to test it because I do not haven't set up the build process for alt:V.