### PR TITLE
Add custom V8 platform

### DIFF
--- a/client/src/CPlatform.cpp
+++ b/client/src/CPlatform.cpp
@@ -1,0 +1,75 @@
+#include "CPlatform.h"
+#include "Log.h"
+#include "cpp-sdk/ICore.h"
+
+#include <chrono>
+
+CPlatform::CPlatform() : defaultPlatform(v8::platform::NewDefaultPlatform()) {}
+
+int CPlatform::NumberOfWorkerThreads()
+{
+    return defaultPlatform->NumberOfWorkerThreads();
+}
+
+std::shared_ptr<v8::TaskRunner> CPlatform::GetForegroundTaskRunner(v8::Isolate* isolate)
+{
+    return defaultPlatform->GetForegroundTaskRunner(isolate);
+}
+
+void CPlatform::CallOnWorkerThread(std::unique_ptr<v8::Task> task)
+{
+    defaultPlatform->CallOnWorkerThread(std::move(task));
+}
+
+void CPlatform::CallDelayedOnWorkerThread(std::unique_ptr<v8::Task> task, double delay_in_seconds)
+{
+    defaultPlatform->CallDelayedOnWorkerThread(std::move(task), delay_in_seconds);
+}
+
+bool CPlatform::IdleTasksEnabled(v8::Isolate* isolate)
+{
+    return defaultPlatform->IdleTasksEnabled(isolate);
+}
+
+std::unique_ptr<v8::JobHandle> CPlatform::PostJob(v8::TaskPriority priority, std::unique_ptr<v8::JobTask> job_state)
+{
+    return defaultPlatform->PostJob(priority, std::move(job_state));
+}
+
+double CPlatform::MonotonicallyIncreasingTime()
+{
+    return defaultPlatform->MonotonicallyIncreasingTime();
+}
+
+double CPlatform::CurrentClockTimeMillis()
+{
+    return defaultPlatform->CurrentClockTimeMillis();
+}
+
+v8::TracingController* CPlatform::GetTracingController()
+{
+    return defaultPlatform->GetTracingController();
+}
+
+v8::Platform::StackTracePrinter CPlatform::GetStackTracePrinter()
+{
+    return defaultPlatform->GetStackTracePrinter();
+}
+
+v8::PageAllocator* CPlatform::GetPageAllocator()
+{
+    return defaultPlatform->GetPageAllocator();
+}
+
+// * Custom overwrites
+
+v8::ZoneBackingAllocator* CPlatform::GetZoneBackingAllocator()
+{
+    return v8::Platform::GetZoneBackingAllocator();
+}
+
+void CPlatform::DumpWithoutCrashing()
+{
+    Log::Error << "[V8] V8 crashed, printing current stack trace: " << Log::Endl;
+    GetStackTracePrinter()();
+}

--- a/client/src/CPlatform.h
+++ b/client/src/CPlatform.h
@@ -37,10 +37,14 @@ class CZoneBackingAllocator : public v8::ZoneBackingAllocator
     {
         size_t size;
         void* ptr;
+
+        Allocation(size_t size, void* ptr) : size(size), ptr(ptr) {}
     };
     struct Deallocation
     {
         void* ptr;
+
+        Deallocation(void* ptr) : ptr(ptr) {}
     };
 
     bool isDebug;

--- a/client/src/CPlatform.h
+++ b/client/src/CPlatform.h
@@ -30,3 +30,31 @@ public:
     v8::ZoneBackingAllocator* GetZoneBackingAllocator() override;
     void DumpWithoutCrashing() override;
 };
+
+class CZoneBackingAllocator : public v8::ZoneBackingAllocator
+{
+    struct Allocation
+    {
+        size_t size;
+        void* ptr;
+    };
+    struct Deallocation
+    {
+        void* ptr;
+    };
+
+    bool isDebug;
+    std::vector<Allocation> allocations;
+    std::vector<Deallocation> deallocations;
+
+    CZoneBackingAllocator(bool isDebug) : isDebug(isDebug) {}
+
+public:
+    MallocFn GetMallocFn() const;
+    FreeFn GetFreeFn() const;
+
+    void PushAllocation(void* ptr, size_t size);
+    void PushDeallocation(void* ptr);
+
+    static CZoneBackingAllocator* Instance();
+};

--- a/client/src/CPlatform.h
+++ b/client/src/CPlatform.h
@@ -60,5 +60,7 @@ public:
     void PushAllocation(void* ptr, size_t size);
     void PushDeallocation(void* ptr);
 
+    void WriteDebugInfoToFile();
+
     static CZoneBackingAllocator* Instance();
 };

--- a/client/src/CPlatform.h
+++ b/client/src/CPlatform.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "v8.h"
+#include "libplatform/libplatform.h"
+
+class CPlatform : public v8::Platform
+{
+    // We don't want to implement the whole V8 platform,
+    // so we just use the default platform with our own overriden methods.
+    std::unique_ptr<v8::Platform> defaultPlatform;
+
+public:
+    CPlatform();
+    ~CPlatform() = default;
+
+    // * Implementations from default platform
+    int NumberOfWorkerThreads() override;
+    std::shared_ptr<v8::TaskRunner> GetForegroundTaskRunner(v8::Isolate* isolate) override;
+    void CallOnWorkerThread(std::unique_ptr<v8::Task> task) override;
+    void CallDelayedOnWorkerThread(std::unique_ptr<v8::Task> task, double delay_in_seconds) override;
+    bool IdleTasksEnabled(v8::Isolate* isolate) override;
+    std::unique_ptr<v8::JobHandle> PostJob(v8::TaskPriority priority, std::unique_ptr<v8::JobTask> job_state) override;
+    double MonotonicallyIncreasingTime() override;
+    double CurrentClockTimeMillis() override;
+    v8::TracingController* GetTracingController() override;
+    StackTracePrinter GetStackTracePrinter() override;
+    v8::PageAllocator* GetPageAllocator() override;
+
+    // * Custom overwrites
+    v8::ZoneBackingAllocator* GetZoneBackingAllocator() override;
+    void DumpWithoutCrashing() override;
+};

--- a/client/src/CV8ScriptRuntime.cpp
+++ b/client/src/CV8ScriptRuntime.cpp
@@ -4,11 +4,12 @@
 #include "inspector/CV8InspectorChannel.h"
 #include "V8Module.h"
 #include "events/Events.h"
+#include "CPlatform.h"
 
 CV8ScriptRuntime::CV8ScriptRuntime()
 {
     v8::V8::SetFlagsFromString("--harmony-import-assertions --short-builtin-calls");
-    platform = v8::platform::NewDefaultPlatform();
+    platform = std::make_unique<CPlatform>();
     v8::V8::InitializePlatform(platform.get());
     v8::V8::InitializeICU((alt::ICore::Instance().GetClientPath() + "/libs/icudtl.dat").CStr());
     v8::V8::Initialize();

--- a/client/src/main.cpp
+++ b/client/src/main.cpp
@@ -1,12 +1,18 @@
 #include "cpp-sdk/SDK.h"
 #include "CV8ScriptRuntime.h"
 #include "Log.h"
+#include "CPlatform.h"
 
 #ifdef ALTV_JS_SHARED
     #define ALTV_JS_EXPORT extern "C" __declspec(dllexport)
 #else
     #define ALTV_JS_EXPORT extern "C"
 #endif
+
+static void DumpDebugInfoCommand(alt::Array<alt::StringView>, void* runtime)
+{
+    CZoneBackingAllocator::Instance()->WriteDebugInfoToFile();
+}
 
 static void HeapCommand(alt::Array<alt::StringView>, void* runtime)
 {
@@ -104,6 +110,7 @@ ALTV_JS_EXPORT void CreateScriptRuntime(alt::ICore* core)
     core->RegisterScriptRuntime("js", &runtime);
 
     // Commands
+    core->SubscribeCommand("dumpdebuginfo", &DumpDebugInfoCommand, &runtime);
     core->SubscribeCommand("heap", &HeapCommand, &runtime);
     core->SubscribeCommand("heapspaces", &HeapSpacesCommand, &runtime);
     core->SubscribeCommand("heapobjects", &HeapObjectsCommand, &runtime);

--- a/client/src/main.cpp
+++ b/client/src/main.cpp
@@ -11,6 +11,11 @@
 
 static void DumpDebugInfoCommand(alt::Array<alt::StringView>, void* runtime)
 {
+    if(!alt::ICore::Instance().IsDebug())
+    {
+        Log::Error << "This command is only available in debug mode" << Log::Endl;
+        return;
+    }
     CZoneBackingAllocator::Instance()->WriteDebugInfoToFile();
 }
 


### PR DESCRIPTION
Implements a custom `v8::Platform` implementation
We can use this to add some debug functionality, like logging allocations and deallocations