### PR TITLE
Add support for node debugger

### DIFF
--- a/server/src/CNodeScriptRuntime.cpp
+++ b/server/src/CNodeScriptRuntime.cpp
@@ -7,7 +7,7 @@ CNodeScriptRuntime::CNodeScriptRuntime()
     int eac;
     const char** eav;
 
-    bool debug = alt::ICore::Instance().GetServerConfig()["node-debug"].ToBool();
+    bool debug = alt::ICore::Instance().GetServerConfig()["node-debug"] && alt::ICore::Instance().GetServerConfig()["node-debug"].ToBool();
     const char* argv[] = { "alt-server", "--experimental-modules",  "--es-module-specifier-resolution=node", "--trace-warnings", debug ? "--inspect" : ""};
     int argc = sizeof(argv) / sizeof(const char*);
 

--- a/server/src/CNodeScriptRuntime.cpp
+++ b/server/src/CNodeScriptRuntime.cpp
@@ -7,7 +7,8 @@ CNodeScriptRuntime::CNodeScriptRuntime()
     int eac;
     const char** eav;
 
-    const char* argv[] = { "alt-server", "--experimental-modules", "--es-module-specifier-resolution=node", "--trace-warnings" };
+    bool debug = alt::ICore::Instance().GetServerConfig()["node-debug"].ToBool();
+    const char* argv[] = { "alt-server", "--experimental-modules",  "--es-module-specifier-resolution=node", "--trace-warnings", debug ? "--inspect" : ""};
     int argc = sizeof(argv) / sizeof(const char*);
 
     node::Init(&argc, argv, &eac, &eav);


### PR DESCRIPTION
When node-debug flag is set to true in server config, the js module will start with --inspect command line flag (debugger)