### PR TITLE
Update node options for nodejs v17.x & Add build.bat vs22 support

### DIFF
--- a/server/build.bat
+++ b/server/build.bat
@@ -1,7 +1,7 @@
 @echo off
 mkdir build
 pushd build
-cmake -G"Visual Studio 16" -A x64 -DJS_MODULE_VERSION=DEV ..
+cmake . -A x64 -DJS_MODULE_VERSION=DEV ..
 cmake --build . --config Release
 popd
 

--- a/server/generate.bat
+++ b/server/generate.bat
@@ -1,5 +1,5 @@
 @echo off
 if not exist build mkdir build
 cd build
-cmake -G"Visual Studio 16" -A x64 -DJS_MODULE_VERSION="internal" ..
+cmake . -A x64 -DJS_MODULE_VERSION="internal" ..
 cd ../

--- a/server/src/CNodeScriptRuntime.cpp
+++ b/server/src/CNodeScriptRuntime.cpp
@@ -85,7 +85,8 @@ void CNodeScriptRuntime::OnDispose()
 
 std::vector<std::string> CNodeScriptRuntime::GetNodeArgs()
 {
-    std::vector<std::string> args = { "alt-server", "--experimental-modules", "--es-module-specifier-resolution=node", "--trace-warnings" };
+    // https://nodejs.org/docs/latest-v17.x/api/cli.html#options
+    std::vector<std::string> args = { "alt-server", "--experimental-specifier-resolution=node", "--trace-warnings" };
 
     alt::config::Node moduleConfig = alt::ICore::Instance().GetServerConfig()["js-module"];
     if(!moduleConfig.IsDict()) return args;


### PR DESCRIPTION
Updated the node start options to latest v17.x standards and updated the `build.bat` and `generate.bat` to support visual studio 2022

 Node resolution algorithm for resolving ES module specifiers flag has been tested with following snippet:

server.js:
```js
import * as alt from 'alt-server';
import defaultImp, { testValue } from './test'; 

alt.log(defaultImp, testValue); // prints "test worked", 10 so node resolution works
```

test.js:
```js
export const testValue = 10;

export default "test worked";
```