### PR TITLE
client: Add eval option to worker #164

### DIFF
--- a/client/src/CV8Resource.cpp
+++ b/client/src/CV8Resource.cpp
@@ -153,6 +153,7 @@ bool CV8ResourceImpl::Start()
         ctx->Global()->Set(ctx, V8Helpers::JSValue("__internal_set_exports"), v8::Function::New(ctx, &StaticSetExports).ToLocalChecked());
         ctx->Global()->Set(ctx, V8Helpers::JSValue("__internal_bindings_code"), V8Helpers::JSValue(JSBindings::GetBindingsCode()));
         ctx->Global()->Set(ctx, V8Helpers::JSValue("__internal_main_path"), V8Helpers::JSValue(path));
+        ctx->Global()->Set(ctx, V8Helpers::JSValue("__internal_eval"), V8Helpers::JSValue(false));
 
         bool res = curModule->InstantiateModule(ctx, CV8ScriptRuntime::ResolveModule).IsJust();
 

--- a/client/src/bindings/Worker.cpp
+++ b/client/src/bindings/Worker.cpp
@@ -14,9 +14,15 @@ static void Constructor(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
     V8_GET_ISOLATE_CONTEXT_RESOURCE();
     V8_CHECK_CONSTRUCTOR();
-    V8_CHECK_ARGS_LEN(1);
+    V8_CHECK_ARGS_LEN2(1, 2);
 
     V8_ARG_TO_STRING(1, path);
+
+    bool isEval = false;
+    if(info.Length() == 2){
+        V8_ARG_TO_BOOLEAN(2, eval);
+        isEval = eval;
+    }
 
     std::string origin = V8Helpers::GetCurrentSourceOrigin(isolate);
 
@@ -25,7 +31,7 @@ static void Constructor(const v8::FunctionCallbackInfo<v8::Value>& info)
 
     std::string filePath = pathInfo.prefix + pathInfo.fileName;
 
-    CWorker* worker = new CWorker(filePath, static_cast<CV8ResourceImpl*>(resource));
+    CWorker* worker = new CWorker(filePath, isEval, static_cast<CV8ResourceImpl*>(resource));
     info.This()->SetInternalField(0, v8::External::New(isolate, worker));
     static_cast<CV8ResourceImpl*>(resource)->AddWorker(worker);
 }

--- a/client/src/bootstrap.js
+++ b/client/src/bootstrap.js
@@ -4,18 +4,18 @@ import * as native from "natives";
 
 let mainPath = __internal_main_path;
 let isEval = __internal_eval;
-if(!isEval && mainPath[0] !== "/") mainPath = "/" + mainPath;
+if (!isEval && mainPath[0] !== "/") mainPath = "/" + mainPath;
 try {
     // Load the main file or the script if eval
     let module;
-    if(isEval) {
+    if (isEval) {
         eval(mainPath);
-    }else{
+    }
+    else {
         module = await import(mainPath);
         __internal_set_exports(module);
     }
-}
-catch(e) {
+} catch (e) {
     let location = `${alt.Resource.current.name}:${mainPath}:${e.lineNumber ?? 0}`;
     alt.logError(`[V8] Exception at ${location} (${e.message ?? "Unknown error"}) ${e.stack ?? ""}`);
 }

--- a/client/src/bootstrap.js
+++ b/client/src/bootstrap.js
@@ -2,15 +2,18 @@
 import * as alt from "alt";
 import * as native from "natives";
 
-// Load the global bindings code
-new Function("alt", "native", __internal_bindings_code)(alt, native);
-
 let mainPath = __internal_main_path;
-if(mainPath[0] !== "/") mainPath = "/" + mainPath;
+let isEval = __internal_eval;
+if(!isEval && mainPath[0] !== "/") mainPath = "/" + mainPath;
 try {
-    // Load the main file
-    const module = await import(mainPath);
-    __internal_set_exports(module);
+    // Load the main file or the script if eval
+    let module;
+    if(isEval) {
+        eval(mainPath);
+    }else{
+        module = await import(mainPath);
+        __internal_set_exports(module);
+    }
 }
 catch(e) {
     let location = `${alt.Resource.current.name}:${mainPath}:${e.lineNumber ?? 0}`;

--- a/client/src/workers/CWorker.cpp
+++ b/client/src/workers/CWorker.cpp
@@ -10,7 +10,7 @@
 
 #include <functional>
 
-CWorker::CWorker(std::string& filePath, CV8ResourceImpl* resource) : filePath(filePath), resource(resource) {}
+CWorker::CWorker(std::string& filePath, bool& eval, CV8ResourceImpl* resource) : filePath(filePath), eval(eval), resource(resource) {}
 
 void CWorker::Start()
 {
@@ -296,6 +296,7 @@ void CWorker::SetupGlobals()
     global->Set(context.Get(isolate), V8Helpers::JSValue("__internal_get_exports"), v8::Function::New(context.Get(isolate), &StaticRequire).ToLocalChecked());
     global->Set(context.Get(isolate), V8Helpers::JSValue("__internal_bindings_code"), V8Helpers::JSValue(JSBindings::GetBindingsCode()));
     global->Set(context.Get(isolate), V8Helpers::JSValue("__internal_main_path"), V8Helpers::JSValue(filePath));
+    global->Set(context.Get(isolate), V8Helpers::JSValue("__internal_eval"), V8Helpers::JSValue(eval));
 }
 
 v8::MaybeLocal<v8::Module> CWorker::Import(v8::Local<v8::Context> context, v8::Local<v8::String> specifier, v8::Local<v8::FixedArray>, v8::Local<v8::Module> referrer)

--- a/client/src/workers/CWorker.cpp
+++ b/client/src/workers/CWorker.cpp
@@ -10,7 +10,7 @@
 
 #include <functional>
 
-CWorker::CWorker(std::string& filePath, bool& eval, CV8ResourceImpl* resource) : filePath(filePath), eval(eval), resource(resource) {}
+CWorker::CWorker(std::string& filePath, bool eval, CV8ResourceImpl* resource) : filePath(filePath), eval(eval), resource(resource) {}
 
 void CWorker::Start()
 {

--- a/client/src/workers/CWorker.h
+++ b/client/src/workers/CWorker.h
@@ -68,7 +68,7 @@ private:
     }
 
 public:
-    CWorker(std::string& filePath, bool& eval, CV8ResourceImpl* resource);
+    CWorker(std::string& filePath, bool eval, CV8ResourceImpl* resource);
     ~CWorker() = default;
 
     void Start();

--- a/client/src/workers/CWorker.h
+++ b/client/src/workers/CWorker.h
@@ -25,6 +25,7 @@ public:
 
 private:
     std::string filePath;
+    bool eval;
     std::thread thread;
     CV8ResourceImpl* resource;
     bool shouldTerminate = false;
@@ -67,7 +68,7 @@ private:
     }
 
 public:
-    CWorker(std::string& filePath, CV8ResourceImpl* resource);
+    CWorker(std::string& filePath, bool& eval, CV8ResourceImpl* resource);
     ~CWorker() = default;
 
     void Start();


### PR DESCRIPTION
Related to #164 

Adds the optional parameter eval to the worker constructor. If eval is given and true, the provided string will be executed as eval. 

The architecture was designed following the eval option of Nodejs.
