### PR TITLE
Refactor JS utils and add Keybind

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -80,5 +80,5 @@
         "*.gen": "cpp"
     },
     "editor.defaultFormatter": "xaver.clang-format",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -80,5 +80,5 @@
         "*.gen": "cpp"
     },
     "editor.defaultFormatter": "xaver.clang-format",
-    "editor.formatOnSave": false
+    "editor.formatOnSave": true
 }


### PR DESCRIPTION
Added `alt.Utils.Keybind`:
```js
// single keycode
const bind = new alt.Utils.Keybind(71, () => {
  alt.log('pressed g')
})

// two keycodes (similar to two separate keybinds with the same handler)
const bind = new alt.Utils.Keybind([71, 75], () => {
  alt.log('pressed g or h')
})

// What key event to use (keyup or keydown) can be specified explicitly (keyup by default)
const bind = new alt.Utils.Keybind(71, () => {
  alt.log('keydown g')
}, 'keydown')
```