### PR TITLE
shared: Fix genericLog string format

### DIFF
--- a/shared/bindings/Logging.js
+++ b/shared/bindings/Logging.js
@@ -3187,7 +3187,10 @@ function stripVTControlCharacters(str) {
 inspect({});
 
 function genericLog(type, ...args) {
-    const logArgs = args.map((arg) => inspect(arg, { colors: type === 0 }));
+    const logArgs = args.map((arg) => {
+      if (typeof arg === 'string') return arg;
+      return inspect(arg, { colors: type === 0 });
+    });
     __printLog(type, ...logArgs);
 }
 __global.genericLog = genericLog;


### PR DESCRIPTION
How it looks like before fix:
![изображение](https://user-images.githubusercontent.com/54737754/194958281-5c40e7d1-a186-40e3-8fe4-583aec641de4.png)
after:
![изображение](https://user-images.githubusercontent.com/54737754/194958428-2b6ec550-3eb0-4103-ba27-ee631b244492.png)
