### PR TITLE
docs: Update client building

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -28,9 +28,9 @@ so make sure you have properly replaced the file.
 ## Client
 
 ### Building
-To build the client module simply run the `build-debug.bat` script.
+To build the client module simply run the `build.bat` script.
 
-Make sure to actually run the build-**debug**.bat. The `build.bat` file is for statically building the module,
+Make sure that `DYNAMIC_BUILD` equals `1`. Otherwise it builds the static module,
 which is only used internally.
 
 > For the client module there is also a VSCode task available, to build it


### PR DESCRIPTION
updated explanation for client building, because `build-debug.bat` was removed in https://github.com/altmp/altv-js-module/commit/b83636265270b09230417d6507abcf7790df74a4