### PR TITLE
Add WeaponObject.getByID and WeaponObject.getByScriptID methods

### DIFF
--- a/client/src/bindings/WeaponObject.cpp
+++ b/client/src/bindings/WeaponObject.cpp
@@ -118,12 +118,19 @@ static void StaticGetByID(const v8::FunctionCallbackInfo<v8::Value>& info)
     V8_ARG_TO_INT(1, id);
 
     auto allWeaponObjects = resource->GetAllWeaponObjects();
-    for (auto& weaponObject : allWeaponObjects)
-    {
-        if (weaponObject->GetID() == id)
+    v8::Local<v8::Value> obj;
+
+    for (uint32_t i = 0; i < allWeaponObjects->Length(); i++) {
+        if (allWeaponObjects->Get(ctx, i).ToLocal(&obj))
         {
-            V8_RETURN_BASE_OBJECT(weaponObject);
-            return;
+            auto entity = V8Entity::Get(obj)->GetHandle();
+            auto weaponObj = entity ? entity->As<alt::ILocalObject>() : nullptr;
+
+            if (weaponObj && weaponObj->GetID() == id)
+            {
+                V8_RETURN_BASE_OBJECT(weaponObj);
+                return;
+            }
         }
     }
 
@@ -137,12 +144,19 @@ static void StaticGetByScriptID(const v8::FunctionCallbackInfo<v8::Value>& info)
     V8_ARG_TO_INT(1, scriptId);
 
     auto allWeaponObjects = resource->GetAllWeaponObjects();
-    for (auto& weaponObject : allWeaponObjects)
-    {
-        if (weaponObject->GetScriptID() == scriptId)
+    v8::Local<v8::Value> obj;
+
+    for (uint32_t i = 0; i < allWeaponObjects->Length(); i++) {
+        if (allWeaponObjects->Get(ctx, i).ToLocal(&obj))
         {
-            V8_RETURN_BASE_OBJECT(weaponObject);
-            return;
+            auto entity = V8Entity::Get(obj)->GetHandle();
+            auto weaponObj = entity ? entity->As<alt::ILocalObject>() : nullptr;
+
+            if (weaponObj && weaponObj->GetScriptID() == scriptId)
+            {
+                V8_RETURN_BASE_OBJECT(weaponObj);
+                return;
+            }
         }
     }
 

--- a/client/src/bindings/WeaponObject.cpp
+++ b/client/src/bindings/WeaponObject.cpp
@@ -117,7 +117,7 @@ static void StaticGetByID(const v8::FunctionCallbackInfo<v8::Value>& info)
     V8_CHECK_ARGS_LEN(1);
     V8_ARG_TO_INT(1, id);
 
-    auto allWeaponObjects = alt::ICore::Instance().GetWeaponObjects();
+    auto allWeaponObjects = resource->GetAllWeaponObjects();
     for (auto& weaponObject : allWeaponObjects)
     {
         if (weaponObject->GetID() == id)
@@ -136,7 +136,7 @@ static void StaticGetByScriptID(const v8::FunctionCallbackInfo<v8::Value>& info)
     V8_CHECK_ARGS_LEN(1);
     V8_ARG_TO_INT(1, scriptId);
 
-    auto allWeaponObjects = alt::ICore::Instance().GetWeaponObjects();
+    auto allWeaponObjects = resource->GetAllWeaponObjects();
     for (auto& weaponObject : allWeaponObjects)
     {
         if (weaponObject->GetScriptID() == scriptId)

--- a/client/src/bindings/WeaponObject.cpp
+++ b/client/src/bindings/WeaponObject.cpp
@@ -117,21 +117,11 @@ static void StaticGetByID(const v8::FunctionCallbackInfo<v8::Value>& info)
     V8_CHECK_ARGS_LEN(1);
     V8_ARG_TO_INT(1, id);
 
-    auto allWeaponObjects = resource->GetAllWeaponObjects();
-    v8::Local<v8::Value> obj;
+    alt::IBaseObject* baseObject = alt::ICore::Instance().GetBaseObjectByID(alt::IBaseObject::Type::LOCAL_OBJECT, id);
 
-    for (uint32_t i = 0; i < allWeaponObjects->Length(); i++) {
-        if (allWeaponObjects->Get(ctx, i).ToLocal(&obj))
-        {
-            auto entity = V8Entity::Get(obj)->GetHandle();
-            auto weaponObj = entity ? entity->As<alt::ILocalObject>() : nullptr;
-
-            if (weaponObj && weaponObj->GetID() == id)
-            {
-                V8_RETURN_BASE_OBJECT(weaponObj);
-                return;
-            }
-        }
+    if(baseObject && baseObject->GetType() == alt::IEntity::Type::LOCAL_OBJECT)
+    {
+        V8_RETURN_BASE_OBJECT(baseObject);
     }
 
     V8_RETURN_NULL();
@@ -143,21 +133,11 @@ static void StaticGetByScriptID(const v8::FunctionCallbackInfo<v8::Value>& info)
     V8_CHECK_ARGS_LEN(1);
     V8_ARG_TO_INT(1, scriptId);
 
-    auto allWeaponObjects = resource->GetAllWeaponObjects();
-    v8::Local<v8::Value> obj;
+    alt::IWorldObject* entity = alt::ICore::Instance().GetWorldObjectByScriptID(scriptId);
 
-    for (uint32_t i = 0; i < allWeaponObjects->Length(); i++) {
-        if (allWeaponObjects->Get(ctx, i).ToLocal(&obj))
-        {
-            auto entity = V8Entity::Get(obj)->GetHandle();
-            auto weaponObj = entity ? entity->As<alt::ILocalObject>() : nullptr;
-
-            if (weaponObj && weaponObj->GetScriptID() == scriptId)
-            {
-                V8_RETURN_BASE_OBJECT(weaponObj);
-                return;
-            }
-        }
+    if(entity && (entity->GetType() == alt::IWorldObject::Type::LOCAL_OBJECT))
+    {
+        V8_RETURN_BASE_OBJECT(entity);
     }
 
     V8_RETURN_NULL();

--- a/client/src/bindings/WeaponObject.cpp
+++ b/client/src/bindings/WeaponObject.cpp
@@ -111,6 +111,44 @@ static void CountGetter(v8::Local<v8::String> name, const v8::PropertyCallbackIn
     V8_RETURN_UINT(alt::ICore::Instance().GetWeaponObjects().size());
 }
 
+static void StaticGetByID(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+    V8_GET_ISOLATE_CONTEXT_RESOURCE();
+    V8_CHECK_ARGS_LEN(1);
+    V8_ARG_TO_INT(1, id);
+
+    auto allWeaponObjects = alt::ICore::Instance().GetWeaponObjects();
+    for (auto& weaponObject : allWeaponObjects)
+    {
+        if (weaponObject->GetID() == id)
+        {
+            V8_RETURN_BASE_OBJECT(weaponObject);
+            return;
+        }
+    }
+
+    V8_RETURN_NULL();
+}
+
+static void StaticGetByScriptID(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+    V8_GET_ISOLATE_CONTEXT_RESOURCE();
+    V8_CHECK_ARGS_LEN(1);
+    V8_ARG_TO_INT(1, scriptId);
+
+    auto allWeaponObjects = alt::ICore::Instance().GetWeaponObjects();
+    for (auto& weaponObject : allWeaponObjects)
+    {
+        if (weaponObject->GetScriptID() == scriptId)
+        {
+            V8_RETURN_BASE_OBJECT(weaponObject);
+            return;
+        }
+    }
+
+    V8_RETURN_NULL();
+}
+
 extern V8Class v8LocalObject;
 extern V8Class v8WeaponObject("WeaponObject",
                               v8LocalObject,
@@ -122,6 +160,8 @@ extern V8Class v8WeaponObject("WeaponObject",
 
                                   V8Helpers::SetStaticAccessor(isolate, tpl, "all", &AllGetter);
                                   V8Helpers::SetStaticAccessor(isolate, tpl, "count", &CountGetter);
+                                  V8Helpers::SetStaticMethod(isolate, tpl, "getByScriptID", StaticGetByScriptID);
+                                  V8Helpers::SetStaticMethod(isolate, tpl, "getByID", StaticGetByID);
 
                                   V8Helpers::SetAccessor<ILocalObject, int, &ILocalObject::GetTintIndex, &ILocalObject::SetTintIndex>(isolate, tpl, "tintIndex");
                                   V8Helpers::SetMethod(isolate, tpl, "setComponentTintIndex", &GetComponentTintIndex);


### PR DESCRIPTION
This PR fixes https://github.com/altmp/altv-js-module/issues/295 by adding `WeaponObject.getByID` and `WeaponObject.getByScriptID` methods