### PR TITLE
Fix Vector.normalize() returning NaNs when dividing by zero

### DIFF
--- a/shared/bindings/Vector2.js
+++ b/shared/bindings/Vector2.js
@@ -111,7 +111,7 @@ alt.Vector2.prototype.inverse = function() {
 
 alt.Vector2.prototype.normalize = function() {
     const length = this.length;
-    return new alt.Vector2(this.x / length, this.y / length);
+    return new alt.Vector2(this.x == 0 ? 0 : this.x / length, this.y == 0 ? 0 : this.y / length);
 }
 
 alt.Vector2.prototype.distanceTo = function(vector) {

--- a/shared/bindings/Vector3.js
+++ b/shared/bindings/Vector3.js
@@ -136,7 +136,7 @@ alt.Vector3.prototype.inverse = function() {
 
 alt.Vector3.prototype.normalize = function() {
     const length = this.length;
-    return new alt.Vector3(this.x / length, this.y / length, this.z / length);
+    return new alt.Vector3(this.x == 0 ? 0 : this.x / length, this.y == 0 ? 0: this.y / length, this.z == 0 ? 0 : this.z / length);
 }
 
 alt.Vector3.prototype.distanceTo = function(vector) {


### PR DESCRIPTION
This PR fixes Issue https://github.com/altmp/altv-js-module/issues/266