### PR TITLE
Add missing VirtualEntity and VirtualEntityGroup static methods

### DIFF
--- a/shared/bindings/VirtualEntity.cpp
+++ b/shared/bindings/VirtualEntity.cpp
@@ -35,6 +35,42 @@ static void Constructor(const v8::FunctionCallbackInfo<v8::Value>& info)
     V8_BIND_BASE_OBJECT(virtualEntity, "Failed to create virtual entity");
 }
 
+static void StaticGetByID(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+    V8_GET_ISOLATE_CONTEXT_RESOURCE();
+    V8_CHECK_ARGS_LEN(1);
+
+    V8_ARG_TO_INT(1, id);
+
+    alt::IBaseObject* entity = alt::ICore::Instance().GetBaseObjectByID(alt::IBaseObject::Type::VIRTUAL_ENTITY, id);
+
+    if(entity)
+    {
+        V8_RETURN_BASE_OBJECT(entity);
+        return;
+    }
+
+    V8_RETURN_NULL();
+}
+
+static void StaticGetByRemoteId(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+    V8_GET_ISOLATE_CONTEXT_RESOURCE();
+    V8_CHECK_ARGS_LEN(1);
+
+    V8_ARG_TO_INT32(1, id);
+
+    alt::IBaseObject* entity = alt::ICore::Instance().GetBaseObjectByRemoteID(alt::IBaseObject::Type::VIRTUAL_ENTITY, id);
+
+    if(entity)
+    {
+        V8_RETURN_BASE_OBJECT(entity);
+        return;
+    }
+
+    V8_RETURN_NULL();
+}
+
 static void AllGetter(v8::Local<v8::String> name, const v8::PropertyCallbackInfo<v8::Value>& info)
 {
     V8_GET_ISOLATE_CONTEXT_RESOURCE();
@@ -196,6 +232,9 @@ extern V8Class v8VirtualEntity("VirtualEntity",
                                [](v8::Local<v8::FunctionTemplate> tpl)
                                {
                                    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+
+                                   V8Helpers::SetStaticMethod(isolate, tpl, "getByID", StaticGetByID);
+                                   V8Helpers::SetStaticMethod(isolate, tpl, "getByRemoteID", StaticGetByRemoteId);
 
                                    V8Helpers::SetStaticAccessor(isolate, tpl, "all", AllGetter);
 

--- a/shared/bindings/VirtualEntity.cpp
+++ b/shared/bindings/VirtualEntity.cpp
@@ -53,6 +53,8 @@ static void StaticGetByID(const v8::FunctionCallbackInfo<v8::Value>& info)
     V8_RETURN_NULL();
 }
 
+#ifdef ALT_CLIENT_API
+
 static void StaticGetByRemoteId(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
     V8_GET_ISOLATE_CONTEXT_RESOURCE();
@@ -70,6 +72,8 @@ static void StaticGetByRemoteId(const v8::FunctionCallbackInfo<v8::Value>& info)
 
     V8_RETURN_NULL();
 }
+
+#endif
 
 static void AllGetter(v8::Local<v8::String> name, const v8::PropertyCallbackInfo<v8::Value>& info)
 {
@@ -234,7 +238,9 @@ extern V8Class v8VirtualEntity("VirtualEntity",
                                    v8::Isolate* isolate = v8::Isolate::GetCurrent();
 
                                    V8Helpers::SetStaticMethod(isolate, tpl, "getByID", StaticGetByID);
+#ifdef ALT_CLIENT_API
                                    V8Helpers::SetStaticMethod(isolate, tpl, "getByRemoteID", StaticGetByRemoteId);
+#endif
 
                                    V8Helpers::SetStaticAccessor(isolate, tpl, "all", AllGetter);
 

--- a/shared/bindings/VirtualEntityGroup.cpp
+++ b/shared/bindings/VirtualEntityGroup.cpp
@@ -37,6 +37,7 @@ static void StaticGetByID(const v8::FunctionCallbackInfo<v8::Value>& info)
 
 #ifdef ALT_CLIENT_API
 
+/* NOTE (xLuxy): Client's are not aware of remote groups (yet?)
 static void StaticGetByRemoteId(const v8::FunctionCallbackInfo<v8::Value>& info)
 {
     V8_GET_ISOLATE_CONTEXT_RESOURCE();
@@ -53,7 +54,7 @@ static void StaticGetByRemoteId(const v8::FunctionCallbackInfo<v8::Value>& info)
     }
 
     V8_RETURN_NULL();
-}
+}*/
 
 #endif
 
@@ -139,7 +140,7 @@ extern V8Class v8VirtualEntityGroup("VirtualEntityGroup",
 
                                         V8Helpers::SetStaticMethod(isolate, tpl, "getByID", StaticGetByID);
 #ifdef ALT_CLIENT_API
-                                        V8Helpers::SetStaticMethod(isolate, tpl, "getByRemoteID", StaticGetByRemoteId);
+                                        // V8Helpers::SetStaticMethod(isolate, tpl, "getByRemoteID", StaticGetByRemoteId);
 #endif
                                         V8Helpers::SetStaticAccessor(isolate, tpl, "all", AllGetter);
 

--- a/shared/bindings/VirtualEntityGroup.cpp
+++ b/shared/bindings/VirtualEntityGroup.cpp
@@ -17,6 +17,24 @@ static void Constructor(const v8::FunctionCallbackInfo<v8::Value>& info)
     V8_BIND_BASE_OBJECT(virtualEntityGroup, "Failed to create virtual entity group");
 }
 
+static void StaticGetByID(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+    V8_GET_ISOLATE_CONTEXT_RESOURCE();
+    V8_CHECK_ARGS_LEN(1);
+
+    V8_ARG_TO_INT(1, id);
+
+    alt::IBaseObject* entity = alt::ICore::Instance().GetBaseObjectByID(alt::IBaseObject::Type::VIRTUAL_ENTITY_GROUP, id);
+
+    if(entity)
+    {
+        V8_RETURN_BASE_OBJECT(entity);
+        return;
+    }
+
+    V8_RETURN_NULL();
+}
+
 static void AllGetter(v8::Local<v8::String> name, const v8::PropertyCallbackInfo<v8::Value>& info)
 {
     V8_GET_ISOLATE_CONTEXT_RESOURCE();
@@ -96,6 +114,8 @@ extern V8Class v8VirtualEntityGroup("VirtualEntityGroup",
                                     [](v8::Local<v8::FunctionTemplate> tpl)
                                     {
                                         v8::Isolate* isolate = v8::Isolate::GetCurrent();
+
+                                        V8Helpers::SetStaticMethod(isolate, tpl, "getByID", StaticGetByID);
 
                                         V8Helpers::SetStaticAccessor(isolate, tpl, "all", AllGetter);
 

--- a/shared/bindings/VirtualEntityGroup.cpp
+++ b/shared/bindings/VirtualEntityGroup.cpp
@@ -35,6 +35,28 @@ static void StaticGetByID(const v8::FunctionCallbackInfo<v8::Value>& info)
     V8_RETURN_NULL();
 }
 
+#ifdef ALT_CLIENT_API
+
+static void StaticGetByRemoteId(const v8::FunctionCallbackInfo<v8::Value>& info)
+{
+    V8_GET_ISOLATE_CONTEXT_RESOURCE();
+    V8_CHECK_ARGS_LEN(1);
+
+    V8_ARG_TO_INT32(1, id);
+
+    alt::IBaseObject* entity = alt::ICore::Instance().GetBaseObjectByRemoteID(alt::IBaseObject::Type::VIRTUAL_ENTITY_GROUP, id);
+
+    if(entity)
+    {
+        V8_RETURN_BASE_OBJECT(entity);
+        return;
+    }
+
+    V8_RETURN_NULL();
+}
+
+#endif
+
 static void AllGetter(v8::Local<v8::String> name, const v8::PropertyCallbackInfo<v8::Value>& info)
 {
     V8_GET_ISOLATE_CONTEXT_RESOURCE();
@@ -116,7 +138,9 @@ extern V8Class v8VirtualEntityGroup("VirtualEntityGroup",
                                         v8::Isolate* isolate = v8::Isolate::GetCurrent();
 
                                         V8Helpers::SetStaticMethod(isolate, tpl, "getByID", StaticGetByID);
-
+#ifdef ALT_CLIENT_API
+                                        V8Helpers::SetStaticMethod(isolate, tpl, "getByRemoteID", StaticGetByRemoteId);
+#endif
                                         V8Helpers::SetStaticAccessor(isolate, tpl, "all", AllGetter);
 
                                         V8Helpers::SetMethod(isolate, tpl, "hasMeta", HasMeta);


### PR DESCRIPTION
- added missing `VirtualEntity.getByID` and `VirtualEntity.getByRemoteID`
- added missing `VirtualEntityGroup.getByID` and `VirtualEntityGroup.getByRemoteID`

NOTE: getByRemoteID currently return `NULL` for both - for VirtualEntity it will be fixed in core.

// Edit: Commented out `VirtualEntityGroup.getByRemoteID` because the client is currently not aware of remote groups.